### PR TITLE
Fix: EFC/CONTADO con CCC del cliente — checkbox visible y correo limpio (NestoAPI#205)

### DIFF
--- a/NestoAPI.Tests/Infrastructure/PedidosVenta/GestorPortesTests.cs
+++ b/NestoAPI.Tests/Infrastructure/PedidosVenta/GestorPortesTests.cs
@@ -1431,5 +1431,91 @@ namespace NestoAPI.Tests.Infraestructure.PedidosVenta
         }
 
         #endregion
+
+        #region Bug — cliente con CCC pero cabecera EFC/CONTADO debe mostrar checkbox y limpiar correo
+
+        [TestMethod]
+        public void CalcularPortes_FormaPagoEFCConCccDelCliente_EsContraReembolsoSiTrue()
+        {
+            // Escenario reproductor: cliente con FP=RCB, plazos=1/30, CCC=1. En la plantilla
+            // de ventas el usuario elige FP=EFC y plazos=CONTADO. La UI no limpia el CCC, así
+            // que CalcularPortes recibe CCC="1". Al persistir, EFC.CCCObligatorio=false anula
+            // el CCC en la cabecera y el pedido se cobra contra reembolso. CalcularPortes debe
+            // reflejarlo para que la UI muestre la casilla "No cobrar comisión por reembolso".
+            var input = new PedidoPortesInput
+            {
+                CodigoPostal = "28100",
+                Ruta = Constantes.Pedidos.RUTA_AGENCIA_FW,
+                FormaPago = Constantes.FormasPago.EFECTIVO,
+                PlazosPago = Constantes.PlazosPago.CONTADO,
+                CCC = "1",
+                PeriodoFacturacion = Constantes.Pedidos.PERIODO_FACTURACION_NORMAL,
+                NotaEntrega = false,
+                EsCanalExterno = false,
+                Iva = Constantes.Empresas.IVA_POR_DEFECTO,
+                BaseImponibleProductos = 50M
+            };
+
+            var resultado = GestorPortes.CalcularPortes(input);
+
+            Assert.IsTrue(resultado.EsContraReembolso,
+                "Con FP=EFC y plazos=CONTADO el pedido es contra reembolso aunque el CCC " +
+                "venga informado del cliente: EFC.CCCObligatorio=false anula el CCC en cabecera.");
+        }
+
+        [TestMethod]
+        public void GestionarLineasPortes_LineaReembolsoPersistidaSinComision_SeQuitaDelDTO()
+        {
+            // Bug: al modificar un pedido con NoCobrarComisionReembolso=true, CalcularPortes
+            // devuelve ComisionReembolso=0. El PUT del controller quita la línea de reembolso
+            // de la BD (cabPedidoVta.LinPedidoVtas) pero NO del DTO (pedido.Lineas), por lo que
+            // el correo de modificación sigue mostrando la línea. GestionarLineasPortes debe
+            // quitarla del DTO aunque la línea ya esté persistida (id != 0), igual que el
+            // controller hace para la línea de portes.
+            var lineaReembolsoPersistida = new LineaPedidoVentaDTO
+            {
+                id = 12345,
+                tipoLinea = Constantes.TiposLineaVenta.CUENTA_CONTABLE,
+                Producto = Constantes.Cuentas.CUENTA_PORTES_VENTA_GENERAL,
+                texto = "Comisión contra reembolso",
+                PrecioUnitario = 3M,
+                Cantidad = 1,
+                almacen = "ALG",
+                delegacion = "ALG",
+                formaVenta = "EFC",
+                estado = Constantes.EstadosLineaVenta.EN_CURSO,
+                usuario = "test"
+            };
+            var lineas = new HashSet<LineaPedidoVentaDTO>
+            {
+                new LineaPedidoVentaDTO
+                {
+                    tipoLinea = Constantes.TiposLineaVenta.PRODUCTO,
+                    Producto = "PROD1",
+                    PrecioUnitario = 50M,
+                    Cantidad = 1,
+                    almacen = "ALG",
+                    delegacion = "ALG",
+                    formaVenta = "EFC",
+                    estado = Constantes.EstadosLineaVenta.EN_CURSO,
+                    usuario = "test"
+                },
+                lineaReembolsoPersistida
+            };
+            var resultado = new ResultadoPortes
+            {
+                EsContraReembolso = true,
+                ComisionReembolso = 0M,
+                PortesGratis = true
+            };
+
+            GestorPortes.GestionarLineasPortes(lineas, resultado, "G21", null);
+
+            Assert.IsFalse(lineas.Contains(lineaReembolsoPersistida),
+                "La línea de reembolso persistida debe quitarse del DTO cuando ComisionReembolso=0, " +
+                "para que el correo de modificación del pedido no la siga mostrando.");
+        }
+
+        #endregion
     }
 }

--- a/NestoAPI/Controllers/PedidosVentaController.cs
+++ b/NestoAPI/Controllers/PedidosVentaController.cs
@@ -1103,6 +1103,20 @@ namespace NestoAPI.Controllers
                         if (lineaReembBD != null)
                         {
                             _ = db.LinPedidoVtas.Remove(lineaReembBD);
+                            // Espejo del DTO (mismo patrón que la línea de portes arriba): el correo
+                            // de modificación lee de pedido.Lineas, así que si la línea ya no debe
+                            // estar en BD también hay que quitarla del DTO para que el correo no la
+                            // siga mostrando.
+                            var lineaReembDTO = pedido.Lineas.FirstOrDefault(l =>
+                                l.tipoLinea == Constantes.TiposLineaVenta.CUENTA_CONTABLE &&
+                                l.Producto != null &&
+                                l.Producto.Trim() == Constantes.Cuentas.CUENTA_PORTES_VENTA_GENERAL &&
+                                l.texto != null &&
+                                l.texto.IndexOf("reembolso", StringComparison.OrdinalIgnoreCase) >= 0);
+                            if (lineaReembDTO != null)
+                            {
+                                pedido.Lineas.Remove(lineaReembDTO);
+                            }
                         }
                     }
                 }

--- a/NestoAPI/Controllers/PedidosVentaController.cs
+++ b/NestoAPI/Controllers/PedidosVentaController.cs
@@ -1118,6 +1118,33 @@ namespace NestoAPI.Controllers
                                 pedido.Lineas.Remove(lineaReembDTO);
                             }
                         }
+                        else
+                        {
+                            // NestoAPI#194 (fix defensivo): yaLlevaReembolsoBD=true confirma que hay
+                            // una línea de comisión por reembolso en estado PENDIENTE/EN_CURSO, pero
+                            // la lookup con Picking==0 no la ha encontrado. La línea está reservada
+                            // por picking y no podemos quitarla sin desreservarla. Hoy esto se
+                            // resolvía silenciosamente y el pedido salía con comisión indebida.
+                            // Loguear a ELMAH para detectarlo: en los últimos 12 meses no se ha dado
+                            // ningún caso en producción, así que no bloqueamos el guardado, solo
+                            // dejamos traza para reaccionar si aparece.
+                            var lineaReembConPicking = cabPedidoVta.LinPedidoVtas.FirstOrDefault(l =>
+                                l.TipoLinea == Constantes.TiposLineaVenta.CUENTA_CONTABLE &&
+                                l.Producto != null &&
+                                l.Producto.Trim() == Constantes.Cuentas.CUENTA_PORTES_VENTA_GENERAL &&
+                                l.Texto != null &&
+                                l.Texto.Contains("reembolso") &&
+                                l.Estado >= Constantes.EstadosLineaVenta.PENDIENTE &&
+                                l.Estado <= Constantes.EstadosLineaVenta.EN_CURSO);
+                            Elmah.ErrorLog.GetDefault(null)?.Log(new Elmah.Error(new Exception(
+                                $"[Comisión reembolso indeleble] Pedido {pedido.empresa}/{pedido.numero}: " +
+                                $"la cabecera deja de ser contra reembolso (FormaPago={pedido.formaPago?.Trim()}, " +
+                                $"CCC={pedido.ccc}, Plazos={pedido.plazosPago?.Trim()}, " +
+                                $"NoCobrarComisionReembolso={pedido.NoCobrarComisionReembolso}) " +
+                                $"pero la línea de comisión Nº_Orden={lineaReembConPicking?.Nº_Orden} no se puede borrar " +
+                                $"(Picking={lineaReembConPicking?.Picking}, Estado={lineaReembConPicking?.Estado}). " +
+                                $"El pedido se está guardando con comisión que ya no procede.")));
+                        }
                     }
                 }
             }

--- a/NestoAPI/Infraestructure/PedidosVenta/GestorPortes.cs
+++ b/NestoAPI/Infraestructure/PedidosVenta/GestorPortes.cs
@@ -157,6 +157,16 @@ namespace NestoAPI.Infraestructure.PedidosVenta
                 cccEfectivo = null;
                 periodoFacturacionEfectivo = Constantes.Pedidos.PERIODO_FACTURACION_NORMAL;
             }
+            // Bug NestoApp/Nesto: si el cliente tiene RCB/CCC en sus condiciones de pago y el usuario
+            // cambia la cabecera a EFC en la plantilla, la UI puede mantener el CCC=cliente.CCC en el
+            // input de CalcularPortes. Al persistir, EFC.CCCObligatorio=false anula el CCC en la
+            // cabecera (PutPedidoVenta, cabPedidoVta.CCC = formaPago.CCCObligatorio ? pedido.ccc : null),
+            // así que el pedido se cobra contra reembolso. Espejamos esa normalización aquí para que
+            // la UI muestre la casilla "No cobrar comisión por reembolso" cuando corresponda.
+            if (formaPagoEfectiva == Constantes.FormasPago.EFECTIVO)
+            {
+                cccEfectivo = null;
+            }
             resultado.EsContraReembolso = EsContraReembolso(
                 formaPagoEfectiva, plazosPagoEfectivo,
                 cccEfectivo, periodoFacturacionEfectivo, input.NotaEntrega);
@@ -396,8 +406,14 @@ namespace NestoAPI.Infraestructure.PedidosVenta
                     }
                 }
             }
-            else if (lineaReembolsoExistente != null && lineaReembolsoExistente.id == 0)
+            else if (lineaReembolsoExistente != null)
             {
+                // A diferencia de la línea de portes (que se protege con id==0 para no borrar
+                // portes traídos por canales externos como Amazon), la línea de comisión por
+                // reembolso solo la genera NestoAPI. Si CalcularPortes dice que ya no procede
+                // (ej. NoCobrarComisionReembolso=true en el PUT) hay que quitarla del DTO
+                // siempre, persistida o no, para que el correo de modificación no la siga
+                // mostrando después de que el PUT la haya borrado de BD.
                 lineas.Remove(lineaReembolsoExistente);
                 resultadoGestion.Modificado = true;
             }


### PR DESCRIPTION
Fixes #205
Fixes #194

## Summary

### #205 — UI oculta + correo incoherente con CCC heredado del cliente

- `GestorPortes.CalcularPortes` normaliza `cccEfectivo = null` cuando la forma de pago es `EFC`, espejando lo que `PutPedidoVenta` ya hace al persistir (`EFC.CCCObligatorio=false` anula el CCC en cabecera). Con eso la UI muestra la casilla "No cobrar comisión por reembolso" en el flujo cliente con RCB/CCC → pedido EFC.
- `GestorPortes.GestionarLineasPortes` quita la línea de reembolso del DTO aunque ya esté persistida (`id != 0`). La protección `id == 0` se mantiene para portes por el caso canal externo Amazon, pero la línea de comisión solo la genera NestoAPI.
- `PutPedidoVenta`: al borrar la línea de reembolso de `db.LinPedidoVtas` se borra también de `pedido.Lineas`, igual que ya se hace para la línea de portes, para que el correo de modificación no la siga mostrando.

### #194 — Silent no-op cuando la línea de comisión tiene Picking asignado

- Búsqueda en producción de los últimos 12 meses: 0 pedidos con FP=RCB + CCC informado y línea de comisión vigente. El flujo nominal funciona; con #205 también se limpia el DTO.
- Queda un edge case: si la línea de comisión tiene `Picking != 0`, la lookup de la rama de borrado devuelve null y la línea queda silenciosamente. Como fix defensivo, ahora se loguea a ELMAH cuando se detecta esa situación (`yaLlevaReembolsoBD=true` pero lookup vacío). No bloqueamos el guardado por no haber casos reales, pero dejamos traza para reaccionar.

## Test plan

- [x] Tests rojos en `GestorPortes`: `CalcularPortes_FormaPagoEFCConCccDelCliente_EsContraReembolsoSiTrue`, `GestionarLineasPortes_LineaReembolsoPersistidaSinComision_SeQuitaDelDTO`.
- [x] Aplicar fix; ambos verdes sin tocar tests existentes.
- [x] Suite completa: 1358/1358 verdes (7 omitidos).
- [ ] **Pendiente verificación manual #205**: pedido en Nesto/NestoApp con cliente RCB/CCC=1 + EFC/CONTADO → debe aparecer la casilla "No cobrar comisión por reembolso". Marcarla y modificar → el correo de modificación no debe incluir la línea de comisión.
- [ ] **Pendiente monitoreo #194**: vigilar ELMAH por entradas `[Comisión reembolso indeleble]`. Si aparecen, decidir si convertir el log en error 403 o intentar el cleanup del picking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)