### PR TITLE
Fix: GetClientes con filtro=null lanza validación, no NullRef (NestoAPI#201)

### DIFF
--- a/NestoAPI.Tests/Controllers/ClientesControllerTests.cs
+++ b/NestoAPI.Tests/Controllers/ClientesControllerTests.cs
@@ -1,0 +1,56 @@
+using System;
+using FakeItEasy;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NestoAPI.Controllers;
+using NestoAPI.Infraestructure;
+using NestoAPI.Infraestructure.Vendedores;
+
+namespace NestoAPI.Tests.Controllers
+{
+    /// <summary>
+    /// NestoAPI#201: <c>GET /api/Clientes?empresa=1&amp;filtro=</c> (filtro vacío en el query
+    /// string lo binda Web API como <c>null</c>) provoca <c>NullReferenceException</c> en
+    /// <see cref="ClientesController.GetClientes(string, string)"/> al acceder a <c>filtro.Length</c>.
+    /// El overload con vendedor (<see cref="ClientesController.GetClientes(string, string, string)"/>)
+    /// ya gestiona null correctamente lanzando "Por favor, utilice un filtro de al menos 4 caracteres".
+    /// Espejamos ese patrón en los otros dos overloads.
+    /// </summary>
+    [TestClass]
+    public class ClientesControllerTests
+    {
+        private static ClientesController CrearController()
+        {
+            return new ClientesController(
+                A.Fake<IGestorClientes>(),
+                A.Fake<IServicioVendedores>(),
+                A.Fake<IGestorSincronizacion>());
+        }
+
+        [TestMethod]
+        public void GetClientes_EmpresaFiltro_FiltroNull_LanzaExcepcionDeValidacion()
+        {
+            var controller = CrearController();
+
+            var ex = Assert.ThrowsException<Exception>(() =>
+                controller.GetClientes("1", filtro: null));
+
+            // No debe ser NullReferenceException: debe ser la validación de filtro mínimo.
+            Assert.IsNotInstanceOfType(ex, typeof(NullReferenceException),
+                "Filtro null debe disparar la validación de 4 caracteres, no un NullRef.");
+            StringAssert.Contains(ex.Message, "4 caracteres");
+        }
+
+        [TestMethod]
+        public void GetClientes_SoloFiltro_FiltroNull_LanzaExcepcionDeValidacion()
+        {
+            var controller = CrearController();
+
+            var ex = Assert.ThrowsException<Exception>(() =>
+                controller.GetClientes(filtro: null));
+
+            Assert.IsNotInstanceOfType(ex, typeof(NullReferenceException),
+                "Filtro null debe disparar la validación de 4 caracteres, no un NullRef.");
+            StringAssert.Contains(ex.Message, "4 caracteres");
+        }
+    }
+}

--- a/NestoAPI.Tests/NestoAPI.Tests.csproj
+++ b/NestoAPI.Tests/NestoAPI.Tests.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Controllers\PedidosVentaBuscarLineasTests.cs" />
     <Compile Include="Controllers\OfertasPermitidasFamiliaControllerTests.cs" />
     <Compile Include="Helpers\TestDbAsyncQueryProvider.cs" />
+    <Compile Include="Controllers\ClientesControllerTests.cs" />
     <Compile Include="Controllers\PedidosVentaControllerTests.cs" />
     <Compile Include="Controllers\PedidosVentaServirJuntoTests.cs" />
     <Compile Include="Controllers\PedidosCompraControllerTests.cs" />

--- a/NestoAPI/Controllers/ClientesController.cs
+++ b/NestoAPI/Controllers/ClientesController.cs
@@ -145,7 +145,10 @@ namespace NestoAPI.Controllers
         // GET: api/Clientes
         public IQueryable<ClienteDTO> GetClientes(string empresa, string filtro)
         {
-            if (filtro.Length < 4 && !filtro.All(c => char.IsDigit(c)))
+            // NestoAPI#201: filtro vacío en la query string lo binda Web API como null
+            // (ej. NestoApp al limpiar la barra de búsqueda). Espejamos el patrón del
+            // overload con vendedor.
+            if ((filtro == null) || ((filtro.Length < 4) && (!filtro.All(c => char.IsDigit(c)))))
             {
                 throw new Exception("Por favor, utilice un filtro de al menos 4 caracteres");
             }
@@ -202,8 +205,8 @@ namespace NestoAPI.Controllers
         // GET: api/Clientes
         public IQueryable<ClienteDTO> GetClientes(string filtro)
         {
-
-            if (filtro.Length < 4)
+            // NestoAPI#201: filtro null debe disparar la validación, no NullRef.
+            if ((filtro == null) || (filtro.Length < 4))
             {
                 throw new Exception("Por favor, utilice un filtro de al menos 4 caracteres");
             }


### PR DESCRIPTION
Fixes #201

## Summary

- Dos overloads de `ClientesController.GetClientes` accedían a `filtro.Length` sin null check. NestoApp dispara `GET /api/Clientes?empresa=1&filtro=` al limpiar la barra de búsqueda y Web API binda el query string vacío como `null`, lo que provoca `NullReferenceException`.
- Espejamos el patrón del overload con vendedor (que ya gestiona null correctamente).
- Tests rojos primero en `ClientesControllerTests.cs` (nuevo archivo): filtro null → ahora lanza la validación de 4 caracteres en vez de NullRef.

## Test plan

- [x] Tests rojos `GetClientes_EmpresaFiltro_FiltroNull_LanzaExcepcionDeValidacion` y `GetClientes_SoloFiltro_FiltroNull_LanzaExcepcionDeValidacion` → ambos lanzaban NullRef antes del fix.
- [x] Aplicar fix; ambos verdes.
- [x] Suite completa: 1360/1360 verdes.

## Nota

El issue sugiere también revisar en NestoApp (`selector-clientes.service.ts`) que no se lance la petición cuando el filtro está vacío. No incluido en este PR (queda como defensa adicional client-side si se quiere abrir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)