### PR TITLE
Feat: bloquear CEX y validar Canteras para envíos a Canarias (NestoAPI#204 MVP)

### DIFF
--- a/NestoAPI.Tests/Controllers/CrearEtiquetaPendienteTests.cs
+++ b/NestoAPI.Tests/Controllers/CrearEtiquetaPendienteTests.cs
@@ -695,6 +695,191 @@ namespace NestoAPI.Tests.Controllers
             return envioCreado;
         }
 
+        #region NestoAPI#204 — Canarias / Canteras
+
+        [TestMethod]
+        public async Task CrearEtiquetaPendiente_AgenciaCEX_CodigoPostalCanarias_RetornaBadRequest()
+        {
+            // Reproductor #204: hoy NestoApp manda Agencia=8 (CEX) para CP 35xxx/38xxx, pero CEX
+            // no entrega en Canarias. La API debe rechazar y obligar a usar Canteras.
+            var resultado = await IntentarCrearEtiqueta(
+                agencia: Constantes.Agencias.AGENCIA_CORREOS_EXPRESS,
+                codPostal: "35001",
+                lineas: ProductoDe(500m));
+
+            var badRequest = resultado as BadRequestErrorMessageResult;
+            Assert.IsNotNull(badRequest, "CEX a CP canario debe devolver BadRequest");
+            StringAssert.Contains(badRequest.Message, "Canteras",
+                "El mensaje debe orientar al usuario a la agencia correcta (Canteras).");
+        }
+
+        [TestMethod]
+        public async Task CrearEtiquetaPendiente_AgenciaCEX_CodigoPostalTenerife_RetornaBadRequest()
+        {
+            // Tenerife (CP 38xxx) también es Canarias.
+            var resultado = await IntentarCrearEtiqueta(
+                agencia: Constantes.Agencias.AGENCIA_CORREOS_EXPRESS,
+                codPostal: "38001",
+                lineas: ProductoDe(500m));
+
+            Assert.IsInstanceOfType(resultado, typeof(BadRequestErrorMessageResult));
+        }
+
+        [TestMethod]
+        public async Task CrearEtiquetaPendiente_AgenciaCanteras_CodigoPostalNoCanarias_RetornaBadRequest()
+        {
+            // Canteras solo opera en Canarias.
+            var resultado = await IntentarCrearEtiqueta(
+                agencia: Constantes.Agencias.AGENCIA_CANTERAS,
+                codPostal: "28001",
+                lineas: ProductoDe(500m));
+
+            var badRequest = resultado as BadRequestErrorMessageResult;
+            Assert.IsNotNull(badRequest);
+            StringAssert.Contains(badRequest.Message, "Canarias",
+                "El mensaje debe explicar que Canteras solo opera en Canarias.");
+        }
+
+        [TestMethod]
+        public async Task CrearEtiquetaPendiente_AgenciaCanteras_ImporteBajoSinPortes_RetornaBadRequest()
+        {
+            // Canarias por Canteras exige importe ≥ IMPORTE_MINIMO_CANARIAS (400€) o portes ≥ Portes.CANARIAS (100€).
+            var resultado = await IntentarCrearEtiqueta(
+                agencia: Constantes.Agencias.AGENCIA_CANTERAS,
+                codPostal: "35001",
+                lineas: ProductoDe(50m));
+
+            var badRequest = resultado as BadRequestErrorMessageResult;
+            Assert.IsNotNull(badRequest);
+            StringAssert.Contains(badRequest.Message, "400",
+                "El mensaje debe explicar el mínimo (400€).");
+        }
+
+        [TestMethod]
+        public async Task CrearEtiquetaPendiente_AgenciaCanteras_ImporteSuficiente_CreaEtiqueta()
+        {
+            // Importe del pedido ≥ 400€: Canteras OK.
+            var resultado = await IntentarCrearEtiqueta(
+                agencia: Constantes.Agencias.AGENCIA_CANTERAS,
+                codPostal: "35001",
+                lineas: ProductoDe(450m));
+
+            Assert.IsInstanceOfType(resultado, typeof(CreatedNegotiatedContentResult<NestoAPI.Models.EnvioAgenciaDTO>),
+                "Importe ≥ 400€ debe crear la etiqueta sin error.");
+        }
+
+        [TestMethod]
+        public async Task CrearEtiquetaPendiente_AgenciaCanteras_ConLineaPortesCanarias_CreaEtiqueta()
+        {
+            // Importe bajo pero con línea de portes Canarias (100€): Canteras OK.
+            var lineas = new List<LinPedidoVta>
+            {
+                LineaProducto(50m),
+                LineaPortes(Constantes.Portes.CANARIAS)
+            };
+            var resultado = await IntentarCrearEtiqueta(
+                agencia: Constantes.Agencias.AGENCIA_CANTERAS,
+                codPostal: "35001",
+                lineas: lineas);
+
+            Assert.IsInstanceOfType(resultado, typeof(CreatedNegotiatedContentResult<NestoAPI.Models.EnvioAgenciaDTO>),
+                "Con línea de portes Canarias (100€) debe crear la etiqueta aunque el importe sea bajo.");
+        }
+
+        [TestMethod]
+        public async Task CrearEtiquetaPendiente_AgenciaCanteras_CobrarReembolsoTrue_RetornaBadRequest()
+        {
+            // Canteras no admite contra reembolso (operativa manual sin cobro).
+            var resultado = await IntentarCrearEtiqueta(
+                agencia: Constantes.Agencias.AGENCIA_CANTERAS,
+                codPostal: "35001",
+                lineas: ProductoDe(500m),
+                cobrarReembolso: true,
+                importeReembolso: 100m);
+
+            var badRequest = resultado as BadRequestErrorMessageResult;
+            Assert.IsNotNull(badRequest);
+            StringAssert.Contains(badRequest.Message, "reembolso",
+                "El mensaje debe explicar que Canteras no admite contra reembolso.");
+        }
+
+        private async Task<System.Web.Http.IHttpActionResult> IntentarCrearEtiqueta(
+            int agencia, string codPostal, List<LinPedidoVta> lineas,
+            bool cobrarReembolso = false, decimal? importeReembolso = null)
+        {
+            var pedido = new CabPedidoVta
+            {
+                Empresa = "1  ",
+                Número = 12345,
+                Nº_Cliente = "10000",
+                Contacto = "0  ",
+                LinPedidoVtas = lineas
+            };
+            ConfigurarFakeDbSet(fakePedidos, new List<CabPedidoVta> { pedido }.AsQueryable());
+
+            var direccion = new Cliente
+            {
+                Empresa = "1  ",
+                Nº_Cliente = "10000",
+                Contacto = "0  ",
+                Nombre = "Cliente Test",
+                CodPostal = codPostal,
+                PersonasContactoClientes = new List<PersonaContactoCliente>()
+            };
+            ConfigurarFakeDbSet(fakeClientes, new List<Cliente> { direccion }.AsQueryable());
+            ConfigurarFakeDbSet(fakeEnvios, new List<EnviosAgencia>().AsQueryable());
+
+            A.CallTo(() => fakeEnvios.Add(A<EnviosAgencia>.Ignored))
+                .ReturnsLazily((EnviosAgencia e) => e);
+            A.CallTo(() => db.SaveChangesAsync()).Returns(Task.FromResult(1));
+
+            var request = new CrearEtiquetaPendienteDTO
+            {
+                Empresa = "1  ",
+                Pedido = 12345,
+                Agencia = agencia,
+                Retorno = 1,
+                CobrarReembolso = cobrarReembolso,
+                ImporteReembolso = importeReembolso
+            };
+
+            return await controller.CrearEtiquetaPendiente(request);
+        }
+
+        private static List<LinPedidoVta> ProductoDe(decimal baseImponible)
+        {
+            return new List<LinPedidoVta> { LineaProducto(baseImponible) };
+        }
+
+        private static LinPedidoVta LineaProducto(decimal baseImponible)
+        {
+            return new LinPedidoVta
+            {
+                TipoLinea = Constantes.TiposLineaVenta.PRODUCTO,
+                Producto = "PROD1",
+                Cantidad = 1,
+                Precio = baseImponible,
+                Base_Imponible = baseImponible,
+                Estado = Constantes.EstadosLineaVenta.EN_CURSO
+            };
+        }
+
+        private static LinPedidoVta LineaPortes(decimal importe)
+        {
+            return new LinPedidoVta
+            {
+                TipoLinea = Constantes.TiposLineaVenta.CUENTA_CONTABLE,
+                Producto = Constantes.Cuentas.CUENTA_PORTES_CEX,
+                Texto = "Portes",
+                Cantidad = 1,
+                Precio = importe,
+                Base_Imponible = importe,
+                Estado = Constantes.EstadosLineaVenta.EN_CURSO
+            };
+        }
+
+        #endregion
+
         #region Helpers
 
         private void ConfigurarFakeDbSet<T>(DbSet<T> fakeDbSet, IQueryable<T> data) where T : class

--- a/NestoAPI/Controllers/EnviosAgenciasController.cs
+++ b/NestoAPI/Controllers/EnviosAgenciasController.cs
@@ -243,6 +243,14 @@ namespace NestoAPI.Controllers
                 return BadRequest("No se encontró la dirección del contacto del pedido");
             }
 
+            // NestoAPI#204: validar combinación agencia + destino antes de crear la etiqueta.
+            var errorAgencia = ValidarAgenciaCompatibleConDestino(
+                request.Agencia, direccion.CodPostal?.Trim() ?? "", pedido, request.CobrarReembolso);
+            if (errorAgencia != null)
+            {
+                return BadRequest(errorAgencia);
+            }
+
             var telefono = new Telefono(direccion.Teléfono);
             var correo = new CorreoCliente(direccion.PersonasContactoClientes);
 
@@ -298,6 +306,55 @@ namespace NestoAPI.Controllers
 
             var dto = new EnvioAgenciaDTO(envio);
             return Created(new Uri(Request.RequestUri, envio.Numero.ToString()), dto);
+        }
+
+        /// <summary>
+        /// NestoAPI#204: rechazos por combinación agencia + destino. Devuelve mensaje de error o null
+        /// si la combinación es válida. Cubre:
+        /// - CEX no entrega en Canarias → forzar Canteras.
+        /// - Canteras solo opera en Canarias.
+        /// - Canteras es operativa manual y no admite contra reembolso.
+        /// - Canteras exige importe del pedido ≥ <see cref="Models.Picking.GestorImportesMinimos.IMPORTE_MINIMO_CANARIAS"/>
+        ///   o una línea de portes ≥ <see cref="Constantes.Portes.CANARIAS"/>.
+        /// </summary>
+        private static string ValidarAgenciaCompatibleConDestino(int agencia, string codPostal, CabPedidoVta pedido, bool cobrarReembolso)
+        {
+            bool esCanarias = Infraestructure.PedidosVenta.GestorPortes.EsCanarias(codPostal);
+
+            if (agencia == Constantes.Agencias.AGENCIA_CORREOS_EXPRESS && esCanarias)
+            {
+                return "Correos Express no entrega en Canarias. Usa la agencia Canteras para envíos a Canarias.";
+            }
+
+            if (agencia == Constantes.Agencias.AGENCIA_CANTERAS)
+            {
+                if (!esCanarias)
+                {
+                    return "La agencia Canteras solo opera en Canarias (códigos postales 35xxx y 38xxx).";
+                }
+                if (cobrarReembolso)
+                {
+                    return "La agencia Canteras no admite contra reembolso. Cobra el pedido por otro medio antes de tramitar el envío.";
+                }
+
+                decimal baseImponiblePedido = pedido.LinPedidoVtas?
+                    .Where(l => l.TipoLinea == Constantes.TiposLineaVenta.PRODUCTO)
+                    .Sum(l => l.Base_Imponible) ?? 0M;
+                bool llevaLineaPortesCanarias = pedido.LinPedidoVtas?
+                    .Any(l => l.TipoLinea == Constantes.TiposLineaVenta.CUENTA_CONTABLE
+                        && l.Producto != null
+                        && l.Producto.Trim().StartsWith("624")
+                        && l.Base_Imponible >= Constantes.Portes.CANARIAS) ?? false;
+
+                if (baseImponiblePedido < Models.Picking.GestorImportesMinimos.IMPORTE_MINIMO_CANARIAS
+                    && !llevaLineaPortesCanarias)
+                {
+                    return $"El pedido no llega al mínimo de Canarias ({Models.Picking.GestorImportesMinimos.IMPORTE_MINIMO_CANARIAS:N0} €) " +
+                           $"y no lleva una línea de portes de {Constantes.Portes.CANARIAS:N0} €. Añade portes o aumenta el importe.";
+                }
+            }
+
+            return null;
         }
 
         private static (short Servicio, short Horario, int Pais) ObtenerDefaultsAgencia(int agencia, string codPostal)

--- a/NestoAPI/Models/Constantes.cs
+++ b/NestoAPI/Models/Constantes.cs
@@ -17,6 +17,10 @@ namespace NestoAPI.Models
             public const int AGENCIA_GLOVO = 7;
             public const int AGENCIA_CORREOS_EXPRESS = 8;
             public const int AGENCIA_SENDING = 10;
+            // NestoAPI#204: Canteras (Numero=11) cubre los envíos a Canarias. Operativa manual
+            // por correo (no hay integración) y no admite contra reembolso. Mínimo del pedido
+            // 400€ o línea de portes de 100€ (constantes IMPORTE_MINIMO_CANARIAS y Portes.CANARIAS).
+            public const int AGENCIA_CANTERAS = 11;
             public const int ESTADO_PENDIENTE = -1;
             public const int ESTADO_EN_CURSO = 0;
             public const decimal REEMBOLSO_NO_COBRAR = -1M;


### PR DESCRIPTION
Refs #204 (MVP backend; cierre cuando se complete email + tracking manual)

## Summary

Canteras (Numero=11) ya está dada de alta en BD. Hasta ahora la API aceptaba sin reservas cualquier combinación agencia/destino, así que NestoApp/Nesto seguían mandando Agencia=8 (CEX) para CP de Canarias, donde CEX no entrega.

Validaciones nuevas en `CrearEtiquetaPendiente`:

- **Agencia CEX + CP Canarias (35xxx/38xxx)** → 400 BadRequest indicando que hay que usar Canteras.
- **Agencia Canteras + CP no Canarias** → 400 BadRequest (Canteras solo opera en Canarias).
- **Agencia Canteras + `CobrarReembolso=true`** → 400 BadRequest (operativa manual sin cobro).
- **Agencia Canteras + base imponible del pedido < 400€ Y sin línea de portes ≥ 100€** → 400 BadRequest con mensaje claro de los mínimos.

Reutilizamos las constantes ya existentes `IMPORTE_MINIMO_CANARIAS` (400€) y `Portes.CANARIAS` (100€). Añadida `Constantes.Agencias.AGENCIA_CANTERAS = 11`.

## Fuera de alcance (follow-ups que dejan #204 abierta)

- Endpoint/flujo para enviar el correo manual a Canteras al tramitar.
- Definir dónde se guarda el nº de envío que Canteras devuelve por correo (campo `Numero`, `CodigoBarras`, o nuevo). Habilitar edición desde Nesto (Nesto#359).
- Validación al actualizar (PUT) una etiqueta ya creada — hoy solo se valida al crear.

## Test plan

- [x] 7 tests rojos en `CrearEtiquetaPendienteTests.cs` (sección NestoAPI#204) cubriendo todas las ramas (CEX→Canarias, Canteras→no Canarias, Canteras+reembolso, importe bajo sin portes, importe suficiente, con línea de portes Canarias).
- [x] Aplicar fix; los 7 verdes sin tocar tests existentes.
- [x] Suite global: 1363/1363 verdes, 7 omitidos.

## Notas

- Canteras (Numero=11) ya creada en BD con campos a NULL (sin integración, sin reembolso) — confirmado por el dueño del proyecto antes del PR.
- La UI complementaria (mostrar Canteras seleccionable, propagar mensajes de error al usuario) vive en Nesto#359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)